### PR TITLE
Additional options for tags

### DIFF
--- a/jquery.tagcanvas.js
+++ b/jquery.tagcanvas.js
@@ -680,7 +680,7 @@ Oproto.DrawColourImage = function(c,x,y,w,h,colour,tag,x1,y1) {
 	  var scale = tag.txtScale;
 	  var th = scale * tag.textHeight;
 	  var cw = tag.MeasureText(tag.tc.ctxt);
-	  tag.image = TextToCanvas(tag.text, th + 'px ' + tag.textFont, th, cw, th, tag.colour, tag.tc.shadow, scale * tag.tc.shadowBlur,	
+	  tag.image = TextToCanvas(tag.text, th + 'px ' + tag.textFont, th, cw, th-tag.bgBoxPadY, tag.colour, tag.tc.shadow, scale * tag.tc.shadowBlur,
 			  [scale * tag.tc.shadowOffset[0], scale * tag.tc.shadowOffset[1]], scale, scale, cw, tag.line_widths, true, colour, 
 			  colour, scale * tag.bgBoxRadius, scale * tag.bgBoxPadX, scale * tag.bgBoxPadY);
 	  tag.alpha = 1;


### PR DESCRIPTION
I added these options for tags:
bgBox - (true|false) background box on/off
bgBoxPadX - (int) x padding on tag
bgBoxPadY - (int) y padding on tag
bgBoxStroke - (string) outline color for bg box
bgBoxColor - (string) color for bg box
bgBoxRadius - (int) radius of bg box corners

For example, this would make the tags look like a bootstrap labels or buttons (http://getbootstrap.com/components/#labels): 
$('#tag-canvas').tagcanvas({
   'textColour' : '#FFFFFF',
   'bgBox': true,
   'bgBoxPadX' : 6,
   'bgBoxPadY' : 10,
   'bgBoxStroke' : "#5BC0DE",
   'bgBoxColor' : "#5BC0DE",
   'bgBoxRadius' : 5,
});
